### PR TITLE
fixed script messing up terminal

### DIFF
--- a/scripts/gazebo_multi_connect.py
+++ b/scripts/gazebo_multi_connect.py
@@ -10,6 +10,7 @@ import subprocess
 import shlex
 import sys
 import time
+import termios
 import helper_funcs as hp
 
 def create_world():
@@ -62,9 +63,10 @@ if __name__ == '__main__':
     print 'Ctrl-C to quit and close Gazebo'
 
     # Wait for Ctrl-C
+    settings = termios.tcgetattr(sys.stdin)
     key = None
     while key != '\x03':
-        key = hp.get_key()
+        key = hp.get_key(settings)
 
     # Terminate the connections
     for proc in processes:

--- a/scripts/helper_funcs.py
+++ b/scripts/helper_funcs.py
@@ -9,14 +9,14 @@ import sys
 import math
 import numpy as np
 
-def get_key():
+def get_key(settings):
     """
     Return pressed key
     """
     tty.setraw(sys.stdin.fileno())
     select.select([sys.stdin], [], [], 0)
     key = sys.stdin.read(1)
-    termios.tcsetattr(sys.stdin, termios.TCSADRAIN, termios.tcgetattr(sys.stdin))
+    termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)
     return key
 
 def euclid_dist(pt1, pt2):


### PR DESCRIPTION
Run `python scripts/gazebo_multi_connect.py 3`.  After Gazebo launches, press `Ctrl-C` to exit, then verify that the terminal works correctly.
