### PR TITLE
updated to new star positioning

### DIFF
--- a/launch/bringup_multi.launch
+++ b/launch/bringup_multi.launch
@@ -8,12 +8,11 @@
   <arg name="robot" default=""/>
 
   <group ns="$(arg robot)">
-    
     <include file="$(find project_polygon)/launch/ar_pose_multi.launch"/>
 
-    <node name="star_pose" pkg="project_polygon" type="star_center_position.py">
-     <param name="robot_name" value="$(arg robot)"/>
-     <param name="pose_correction" value="0.55"/>
+    <node name="star_center_positioning_node" pkg="project_polygon" type="star_center_position_revised.py">
+      <param name="robot_name" value="$(arg robot)"/>
+      <param name="pose_correction" value="0.55"/>
     </node>
 
     <include file="$(find project_polygon)/launch/bringup_minimal_rev2.launch">
@@ -28,7 +27,5 @@
       <arg name="height" value="$(arg height)"/>
       <arg name="fps" value="$(arg fps)"/>
     </include>
-
   </group>
-
 </launch>

--- a/scripts/star_center_position_revised.py
+++ b/scripts/star_center_position_revised.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+
+""" This code implements a ceiling-marker based localization system.
+    The core of the code is filling out the marker_locators
+    which allow for the specification of the position and orientation
+    of the markers on the ceiling of the room """
+
+import rospy
+from ar_pose.msg import ARMarkers
+from tf.transformations import euler_matrix, euler_from_quaternion, rotation_matrix, quaternion_from_matrix, quaternion_from_euler
+import numpy as np
+from nav_msgs.msg import Odometry
+from geometry_msgs.msg import PoseStamped, Pose, Point, Quaternion
+from std_msgs.msg import Header
+from tf import TransformListener, TransformBroadcaster
+from copy import deepcopy
+from math import sin, cos, pi, atan2, fabs
+from dynamic_reconfigure.server import Server
+from my_pf.cfg import STARPoseConfig
+
+class TransformHelpers:
+    """ Some convenience functions for translating between various representions of a robot pose.
+        TODO: nothing... you should not have to modify these """
+
+    @staticmethod
+    def convert_translation_rotation_to_pose(translation, rotation):
+        """ Convert from representation of a pose as translation and rotation (Quaternion) tuples to a geometry_msgs/Pose message """
+        return Pose(position=Point(x=translation[0],y=translation[1],z=translation[2]), orientation=Quaternion(x=rotation[0],y=rotation[1],z=rotation[2],w=rotation[3]))
+
+    @staticmethod
+    def convert_pose_inverse_transform(pose):
+        """ Helper method to invert a transform (this is built into the tf C++ classes, but ommitted from Python) """
+        translation = np.zeros((4,1))
+        translation[0] = -pose.position.x
+        translation[1] = -pose.position.y
+        translation[2] = -pose.position.z
+        translation[3] = 1.0
+
+        rotation = (pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w)
+        euler_angle = euler_from_quaternion(rotation)
+        rotation = np.transpose(rotation_matrix(euler_angle[2], [0,0,1]))       # the angle is a yaw
+        transformed_translation = rotation.dot(translation)
+
+        translation = (transformed_translation[0], transformed_translation[1], transformed_translation[2])
+        rotation = quaternion_from_matrix(rotation)
+        return (translation, rotation)
+
+    @staticmethod
+    def angle_normalize(z):
+        """ convenience function to map an angle to the range [-pi,pi] """
+        return atan2(sin(z), cos(z))
+
+    @staticmethod
+    def angle_diff(a, b):
+        """ Calculates the difference between angle a and angle b (both should be in radians)
+            the difference is always based on the closest rotation from angle a to angle b
+            examples:
+                angle_diff(.1,.2) -> -.1
+                angle_diff(.1, 2*math.pi - .1) -> .2
+                angle_diff(.1, .2+2*math.pi) -> -.1
+        """
+        a = TransformHelpers.angle_normalize(a)
+        b = TransformHelpers.angle_normalize(b)
+        d1 = a-b
+        d2 = 2*pi - fabs(d1)
+        if d1 > 0:
+            d2 *= -1.0
+        if fabs(d1) < fabs(d2):
+            return d1
+        else:
+            return d2
+
+class MarkerLocator(object):
+    def __init__(self, id, position, yaw):
+        """ Create a MarkerLocator object
+            id: the id of the marker (this is an index based on the file
+                specified in ar_pose_multi.launch)
+            position: this is a tuple of the x,y position of the marker
+            yaw: this is the angle about a normal vector pointed towards
+                 the STAR center ceiling
+        """
+        self.id = id
+        self.position = position
+        self.yaw = yaw
+
+    def get_camera_position(self, marker):
+        """ Outputs the position of the camera in the global coordinates """
+        translation, rotation = TransformHelpers.convert_pose_inverse_transform(marker.pose.pose)
+        euler_angles = euler_from_quaternion(rotation)
+        # correct for coordinate system convention changes between camera and world
+        # Also, the Neato can't fly!
+        translation = np.array([-translation[1], translation[0], 0, 1])
+        # correct for the possibility that the marker is rotated relative to the world coordinate frame
+        rot_mat = rotation_matrix(self.yaw, [0,0,1])
+        translation_rotated = rot_mat.dot(translation)
+
+        print euler_angles
+        xy_yaw = (translation_rotated[0]+self.position[0],
+                  translation_rotated[1]+self.position[1],
+                  self.yaw+euler_angles[2])
+        return xy_yaw
+
+class MarkerProcessor(object):
+    def __init__(self, use_dummy_transform=False):
+        rospy.init_node('star_center_positioning_node')
+
+        self.robot_name = rospy.get_param('~robot_name','')
+        self.odom_frame_name = self.robot_name + '_odom'
+        self.base_link_frame_name = self.robot_name + '_base_link'
+
+        self.marker_locators = {}
+        self.add_marker_locator(MarkerLocator(0,(-6*12*2.54/100.0,0),0))
+        self.add_marker_locator(MarkerLocator(1,(0.0,0.0),pi))
+        self.add_marker_locator(MarkerLocator(2,(0.0,10*12*2.54/100.0),0))
+        self.add_marker_locator(MarkerLocator(3,(-6*12*2.54/100.0,6*12*2.54/100.0),0))
+
+        self.pose_correction = rospy.get_param('~pose_correction',0.0)
+        self.phase_offset = rospy.get_param('~phase_offset',0.0)
+        self.is_flipped = rospy.get_param('~is_flipped',False)
+
+
+        srv = Server(STARPoseConfig, self.config_callback)
+
+        self.marker_sub = rospy.Subscriber("ar_pose_marker",
+                                           ARMarkers,
+                                           self.process_markers)
+        self.odom_sub = rospy.Subscriber("odom", Odometry, self.process_odom, queue_size=10)
+        self.star_pose_pub = rospy.Publisher("STAR_pose",PoseStamped,queue_size=10)
+        self.continuous_pose = rospy.Publisher("STAR_pose_continuous",PoseStamped,queue_size=10)
+        self.tf_listener = TransformListener()
+        self.tf_broadcaster = TransformBroadcaster()
+
+    def add_marker_locator(self, marker_locator):
+        self.marker_locators[marker_locator.id] = marker_locator
+
+    def config_callback(self, config, level):
+        self.phase_offset = config.phase_offset
+        self.pose_correction = config.pose_correction
+        return config
+
+    def process_odom(self, msg):
+        p = PoseStamped(header=Header(stamp=rospy.Time(0), frame_id=self.odom_frame_name),
+                        pose=msg.pose.pose)
+        try:
+            STAR_pose = self.tf_listener.transformPose("STAR", p)
+            STAR_pose.header.stamp = msg.header.stamp
+            self.continuous_pose.publish(STAR_pose)
+        except Exception as inst:
+            print "error is", inst
+
+    def process_markers(self, msg):
+        for marker in msg.markers:
+            # do some filtering basd on prior knowledge
+            # we know the approximate z coordinate and that all angles but yaw should be close to zero
+            euler_angles = euler_from_quaternion((marker.pose.pose.orientation.x,
+                                                  marker.pose.pose.orientation.y,
+                                                  marker.pose.pose.orientation.z,
+                                                  marker.pose.pose.orientation.w))
+            angle_diffs = TransformHelpers.angle_diff(euler_angles[0],pi), TransformHelpers.angle_diff(euler_angles[1],0)
+            print angle_diffs, marker.pose.pose.position.z
+            if (marker.id in self.marker_locators and
+                3.0 <= marker.pose.pose.position.z <= 3.6 and
+                fabs(angle_diffs[0]) <= .4 and
+                fabs(angle_diffs[1]) <= .4):
+                print "FOUND IT!"
+                print "offset", rospy.Time.now() - msg.header.stamp
+                locator = self.marker_locators[marker.id]
+                xy_yaw = list(locator.get_camera_position(marker))
+                if self.is_flipped:
+                    print "WE ARE FLIPPED!!!"
+                    xy_yaw[2] += pi
+                print self.pose_correction
+                print self.phase_offset
+                xy_yaw[0] += self.pose_correction*cos(xy_yaw[2]+self.phase_offset)
+                xy_yaw[1] += self.pose_correction*sin(xy_yaw[2]+self.phase_offset)
+
+                orientation_tuple = quaternion_from_euler(0,0,xy_yaw[2])
+                pose = Pose(position=Point(x=-xy_yaw[0],y=-xy_yaw[1],z=0),
+                            orientation=Quaternion(x=orientation_tuple[0], y=orientation_tuple[1], z=orientation_tuple[2], w=orientation_tuple[3]))
+                # TODO: use markers timestamp instead of now() (unfortunately, not populated currently by ar_pose)
+                pose_stamped = PoseStamped(header=Header(stamp=msg.header.stamp,frame_id="STAR"),pose=pose)
+                # TODO: use frame timestamp instead of now()
+                self.star_pose_pub.publish(pose_stamped)
+                self.fix_STAR_to_odom_transform(pose_stamped)
+
+    def fix_STAR_to_odom_transform(self, msg):
+        """ Super tricky code to properly update map to odom transform... do not modify this... Difficulty level infinity. """
+        (translation, rotation) = TransformHelpers.convert_pose_inverse_transform(msg.pose)
+        p = PoseStamped(pose=TransformHelpers.convert_translation_rotation_to_pose(translation,rotation),header=Header(stamp=rospy.Time(),frame_id=self.base_link_frame_name))
+        try:
+            self.tf_listener.waitForTransform(self.odom_frame_name,self.base_link_frame_name,rospy.Time(),rospy.Duration(1.0))
+        except Exception as inst:
+            print "whoops", inst
+            return
+        print "got transform"
+        self.odom_to_STAR = self.tf_listener.transformPose(self.odom_frame_name, p)
+        (self.translation, self.rotation) = TransformHelpers.convert_pose_inverse_transform(self.odom_to_STAR.pose)
+
+    def broadcast_last_transform(self):
+        """ Make sure that we are always broadcasting the last map to odom transformation.
+            This is necessary so things like move_base can work properly. """
+        if not(hasattr(self,'translation') and hasattr(self,'rotation')):
+            return
+        self.tf_broadcaster.sendTransform(self.translation, self.rotation, rospy.get_rostime(), self.odom_frame_name, "STAR")
+
+    def run(self):
+        r = rospy.Rate(10)
+        while not rospy.is_shutdown():
+            self.broadcast_last_transform()
+            r.sleep()
+
+if __name__ == '__main__':
+    nh = MarkerProcessor(use_dummy_transform=False)
+    nh.run()


### PR DESCRIPTION
Make sure to `git pull upstream master` in `catkin_ws/src/comprobo15` to get the changes that Paul made. Then `catkin_make` in your `catkin_ws`.
Connect to a robot using `python scripts/multi_connect.py` as usual and set the camera threshold using `rosrun rqt_gui rqt_gui` as usual.
Set the robot to be turning in a circle slowly and run `ROS_NAMESPACE=[robot ns] rosrun my_pf calibrate_star_pose_revised.py`. Kill it after the red points complete a full circle. This should set the new calibration parameters (you can see them in `rqt_gui` under `star_center_positioning_node`).
