### PR TITLE
Add fifth ar marker

### DIFF
--- a/launch/ar_pose_multi.launch
+++ b/launch/ar_pose_multi.launch
@@ -2,7 +2,7 @@
   <node name="ar_pose" pkg="ar_pose" type="ar_multi" respawn="false"
     output="screen">
     <param name="marker_pattern_list" type="string"
-      value="$(find ar_pose)/data/object_5x5"/>
+      value="$(find ar_pose)/data/object_5_markers"/>
     <param name="threshold" type="int" value="100"/>
     <param name="publish_tf" type="bool" value="false"/>
   </node>

--- a/launch/ar_pose_multi.launch~
+++ b/launch/ar_pose_multi.launch~
@@ -2,7 +2,7 @@
   <node name="ar_pose" pkg="ar_pose" type="ar_multi" respawn="false"
     output="screen">
     <param name="marker_pattern_list" type="string"
-      value="$(find ar_pose)/data/object_5x5"/>
+      value="$(find ar_pose)/data/object_4x4"/>
     <param name="threshold" type="int" value="100"/>
     <param name="publish_tf" type="bool" value="false"/>
   </node>

--- a/launch/ar_pose_multi.launch~
+++ b/launch/ar_pose_multi.launch~
@@ -1,9 +1,0 @@
-<launch>
-  <node name="ar_pose" pkg="ar_pose" type="ar_multi" respawn="false"
-    output="screen">
-    <param name="marker_pattern_list" type="string"
-      value="$(find ar_pose)/data/object_4x4"/>
-    <param name="threshold" type="int" value="100"/>
-    <param name="publish_tf" type="bool" value="false"/>
-  </node>
-</launch>

--- a/scripts/star_center_position_revised.py
+++ b/scripts/star_center_position_revised.py
@@ -109,10 +109,11 @@ class MarkerProcessor(object):
         self.base_link_frame_name = self.robot_name + '_base_link'
 
         self.marker_locators = {}
-        self.add_marker_locator(MarkerLocator(0,(-6*12*2.54/100.0,0),0))
-        self.add_marker_locator(MarkerLocator(1,(0.0,0.0),pi))
-        self.add_marker_locator(MarkerLocator(2,(0.0,10*12*2.54/100.0),0))
+        self.add_marker_locator(MarkerLocator(0,(-6*12*2.54/100.0, 0),0))
+        self.add_marker_locator(MarkerLocator(1,(0.0, 0.0),pi))
+        self.add_marker_locator(MarkerLocator(2,(0.0,10*12*2.54/100.0), 0))
         self.add_marker_locator(MarkerLocator(3,(-6*12*2.54/100.0,6*12*2.54/100.0),0))
+        self.add_marker_locator(MarkerLocator(4,(0.0, 6*12*2.54/100), pi))
 
         self.pose_correction = rospy.get_param('~pose_correction',0.0)
         self.phase_offset = rospy.get_param('~phase_offset',0.0)


### PR DESCRIPTION
Added fifth ar marker to eliminate dead zone.  Renamed files, removed temp files.
Make sure to `git pull upstream master` in `ar_tools`, which is located in `catkin_ws/src`.
Connect to a single bot using the usual routine (`python scripts/multi_connect.py`, set thresholds with `rqt_gui`).
Open `rviz` and add the topics `STAR_pose` and `STAR_pose_continuous`, setting the arrows to different colors.  Make sure the frame is set to `STAR`.
Drive the robot around the arena with teleop.  Observe that there are no discrepancies with the `STAR_pose` and `STAR_pose_continuous` arrows.
