### PR TITLE
added known STAR pose corrections

### DIFF
--- a/launch/bringup_multi.launch
+++ b/launch/bringup_multi.launch
@@ -6,13 +6,16 @@
   <arg name="height" default="480"/>
   <arg name="fps" default="30"/>
   <arg name="robot" default=""/>
+  <arg name="pose_correction" default=""/>
+  <arg name="phase_offset" default=""/>
 
   <group ns="$(arg robot)">
     <include file="$(find project_polygon)/launch/ar_pose_multi.launch"/>
 
     <node name="star_center_positioning_node" pkg="project_polygon" type="star_center_position_revised.py">
       <param name="robot_name" value="$(arg robot)"/>
-      <param name="pose_correction" value="0.55"/>
+      <param name="pose_correction" value="$(arg pose_correction)"/>
+      <param name="phase_offset" value="$(arg phase_offset)"/>
     </node>
 
     <include file="$(find project_polygon)/launch/bringup_minimal_rev2.launch">

--- a/scripts/multi_connect.py
+++ b/scripts/multi_connect.py
@@ -32,7 +32,7 @@ def connect(ip, namespace, port, fps=10):
 
     try:
         pose_correction, phase_offset = STAR_CORRECTIONS[ip]
-    except:
+    except KeyError:
         pose_correction, phase_offset = 0.0, 0.0
 
     args = args.format(ip, namespace, port, fps, pose_correction, phase_offset)

--- a/scripts/multi_connect.py
+++ b/scripts/multi_connect.py
@@ -14,13 +14,28 @@ import sys
 import termios
 import helper_funcs as hp
 
+STAR_CORRECTIONS = {
+    '192.168.17.201': (0.456, -0.482),
+    '192.168.17.202': (0.578, 0.037),
+    '192.168.17.205': (0.261, -0.706),
+    '192.168.17.207': (0.170, -2.06)
+}
+
 def connect(ip, namespace, port, fps=10):
     """
     Use subprocess to call 'roslaunch project_polygon bringup_multi.launch'
     with the given parameters, return process so it can be killed later
     """
     cmd = ['roslaunch', 'project_polygon', 'bringup_multi.launch']
-    args = 'host:={} robot:={} receive_port:={} fps:={}'.format(ip, namespace, port, fps)
+    args = '''host:={} robot:={} receive_port:={} fps:={} pose_correction:={}
+              phase_offset:={}'''
+
+    try:
+        pose_correction, phase_offset = STAR_CORRECTIONS[ip]
+    except:
+        pose_correction, phase_offset = 0.0, 0.0
+
+    args = args.format(ip, namespace, port, fps, pose_correction, phase_offset)
     cmd.extend(shlex.split(args))
 
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
Connect to a robot as usual with `scripts/multi_connect.py`.
Run `rosrun rqt_gui rqt_gui`.
If the robot was 17.201, 17.202, 17.205, or 17.207, the dynamic reconfigure values for `pose_correction` and `phase offset` should be filled in with the previously found values.  Otherwise, they should both be `0.0`.
